### PR TITLE
Mark tRPC endpoints as public in middleware

### DIFF
--- a/game/src/middleware.ts
+++ b/game/src/middleware.ts
@@ -1,7 +1,9 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
 // Define public routes that can be accessed without authentication
-const isPublicRoute = createRouteMatcher(["/anyone-can-visit-this-route"]);
+const isPublicRoute = createRouteMatcher([
+  "/api/trpc/(.*)", // tRPC handles its own auth
+]);
 
 // Define ignored routes that have no authentication information
 const isIgnoredRoute = createRouteMatcher(["/no-auth-in-this-route"]);


### PR DESCRIPTION
Replace the placeholder public route with a route matcher for /api/trpc/(.*) so tRPC endpoints bypass Clerk middleware (tRPC handles its own auth). Removes the example '/anyone-can-visit-this-route' entry.