### PR TITLE
Remove i18n config and related comment

### DIFF
--- a/game/next.config.mjs
+++ b/game/next.config.mjs
@@ -7,16 +7,5 @@
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,
-
-  /**
-   * If you have the "experimental: { appDir: true }" setting enabled, then you
-   * must comment the below `i18n` config out.
-   *
-   * @see https://github.com/vercel/next.js/issues/41980
-   */
-  i18n: {
-    locales: ["en"],
-    defaultLocale: "en",
-  },
 };
 export default config;


### PR DESCRIPTION
- Delete the i18n configuration and its explanatory comment from game/next.config.mjs, leaving reactStrictMode enabled. This removes the commented guidance about the experimental appDir/i18n conflict and the single-locale config that caused compatibility concerns.