### PR TITLE
Use Clerk getAuth with Next request

### DIFF
--- a/game/src/server/api/trpc.ts
+++ b/game/src/server/api/trpc.ts
@@ -16,7 +16,7 @@
  */
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 
-import { auth } from "@clerk/nextjs/server";
+import { getAuth } from "@clerk/nextjs/server";
 import { prisma } from "@/server/db";
 
 import { env } from "@/env.mjs";
@@ -39,7 +39,7 @@ import { env } from "@/env.mjs";
  * @see https://trpc.io/docs/context
  */
 export const createTRPCContext = async (opts: CreateNextContextOptions) => {
-  const session = await auth();
+  const session = getAuth(opts.req);
 
   const { userId } = session;
   // In Clerk v6, user data is accessed via sessionClaims


### PR DESCRIPTION
Replace import and usage of auth() with getAuth(opts.req) from @clerk/nextjs/server in createTRPCContext. Clerk v6 requires passing the Next.js request to getAuth (synchronous) to access session data such as userId, so this aligns the TRPC context creation with the Clerk v6 API.