### PR TITLE
Fix hasInputField check in ActionButton

### DIFF
--- a/game/src/components/ui/tables/AdvancedDataTable/ActionButton.tsx
+++ b/game/src/components/ui/tables/AdvancedDataTable/ActionButton.tsx
@@ -86,8 +86,8 @@ function handleActionClick(
   if (!player?.id) return;
 
   const hasInputField =
-    Number(building.hasInputField) === 1 ||
-    building.hasInputField !== "undefined";
+    building.hasInputField === 1 ||
+    Number(building.hasInputField) === 1;
 
   const amount = getInputAmount(inputAmountRef);
 


### PR DESCRIPTION
Replace an incorrect string-inequality check with explicit numeric checks. The previous condition used `building.hasInputField !== "undefined"`, which could evaluate true in unintended cases; the new logic checks `building.hasInputField === 1 || Number(building.hasInputField) === 1` to correctly detect either a numeric 1 or the string '1'. This prevents treating non-undefined values as indicating an input field.