### PR TITLE
Hide join input when player has an alliance tag

### DIFF
--- a/game/src/components/features/Alliance/Alliance.tsx
+++ b/game/src/components/features/Alliance/Alliance.tsx
@@ -150,13 +150,15 @@ const Alliance: FC<IAllianceProps> = ({ paPlayer, paTag }) => {
                     </Button>
                   </div>
                 )}
-                <AllianceInput
-                  label="Join alliance"
-                  inputRef={joinAllianceRef}
-                  buttonText="Join"
-                  disabled={isAnyMutationLoading}
-                  onClick={handleJoin}
-                />
+                {!paPlayer.tag && (
+                  <AllianceInput
+                    label="Join alliance"
+                    inputRef={joinAllianceRef}
+                    buttonText="Join"
+                    disabled={isAnyMutationLoading}
+                    onClick={handleJoin}
+                  />
+                )}
               </form>
             </div>
           </div>


### PR DESCRIPTION
Wrap the Join Alliance input in a conditional check so it only renders when the current player has no tag (i.e. is not in an alliance). This prevents showing the join form to players who are already in an alliance and avoids redundant join attempts. Modified game/src/components/features/Alliance/Alliance.tsx.