### PR TITLE
Add horizontal padding

### DIFF
--- a/blog/src/components/Header/Header.astro
+++ b/blog/src/components/Header/Header.astro
@@ -2,7 +2,7 @@
 import HeaderLink from "./HeaderLink.astro";
 ---
 
-<header class="container">
+<header class="container px-4 lg:px-0">
   <nav class="flex justify-between items-center pt-4">
     <div class="mx-auto md:mx-0">
       <img

--- a/blog/src/components/Index/Hero.astro
+++ b/blog/src/components/Index/Hero.astro
@@ -2,7 +2,7 @@
 import CallToAction from "./CallToAction.astro";
 ---
 
-<main class="w-full relative">
+<main class="w-full relative px-4 md:px-0">
   <div
     class="h-[25rem] md:h-[30rem] bg-cool-space-ship bg-cover bg-center flex items-center justify-center"
   >

--- a/blog/src/components/Index/Hero.astro
+++ b/blog/src/components/Index/Hero.astro
@@ -2,7 +2,7 @@
 import CallToAction from "./CallToAction.astro";
 ---
 
-<main class="w-full relative px-4 md:px-0">
+<main class="w-full relative px-4 lg:px-0">
   <div
     class="h-[25rem] md:h-[30rem] bg-cool-space-ship bg-cover bg-center flex items-center justify-center"
   >

--- a/blog/src/components/Index/Intro.astro
+++ b/blog/src/components/Index/Intro.astro
@@ -19,7 +19,7 @@ const features = [
 ];
 ---
 
-<section class="py-14 max-w-6xl mx-auto">
+<section class="py-14 max-w-6xl px-4 lg:px-0">
   <h2 class="text-2xl md:text-3xl font-bold mb-8 text-center">
     What is Earth Doom?
   </h2>


### PR DESCRIPTION
- Add small-screen horizontal padding to the Hero component by adding `px-4 md:px-0` to the <main> element. This ensures consistent side spacing on mobile while preserving the original layout on medium and larger screens.
- Apply consistent small-screen horizontal padding (px-4 lg:px-0) to Header, Hero main, and Intro section to ensure proper spacing on narrow viewports while keeping the layout flush on large screens. Files changed: Header.astro, Hero.astro (also adjusted md:px-0 -> lg:px-0), and Intro.astro.