### PR TITLE
Remove horizontal padding from Hero component

### DIFF
--- a/blog/src/components/Index/Hero.astro
+++ b/blog/src/components/Index/Hero.astro
@@ -2,7 +2,7 @@
 import CallToAction from "./CallToAction.astro";
 ---
 
-<main class="w-full relative px-4 lg:px-0">
+<main class="w-full relative">
   <div
     class="h-[25rem] md:h-[30rem] bg-cool-space-ship bg-cover bg-center flex items-center justify-center"
   >


### PR DESCRIPTION
Remove the px-4 and lg:px-0 classes on the <main> element in blog/src/components/Index/Hero.astro so the hero section can span the full viewport width. Small layout tweak to let the background image reach the edges.